### PR TITLE
単位をbpsからMbpsに修正

### DIFF
--- a/main.go
+++ b/main.go
@@ -159,7 +159,7 @@ func fetchMetrics(opts commandOpts, ss []*IaaSRouter) (map[string]interface{}, e
 		sum := float64(0)
 		monitors := make([]interface{}, 0)
 		for _, p := range usages {
-			v := valueFn(p)
+			v := valueFn(p) / 1000 / 1000 // 単位変換: bps->Mbps
 			m := map[string]interface{}{
 				"traffic": v,
 				"time":    p.GetTime().String(),


### PR DESCRIPTION
closes #5 

#### 元データ

```json
{
  "Data": {
    "2022-11-08T09:15:00+09:00": {
      "In": 0,
      "Out": 3247090
    }
  }
}
```

#### sacloud-router-usageでの出力

```
$ ./sacloud-router-usage --prefix example --zone tk1b --item out --time 1
2022/11/08 09:21:22 example zone:tk1b traffic:3.247090 time:2022-11-08 09:15:00 +0900 JST
2022/11/08 09:21:22 example average_traffic:3.247090
{"75pt":3.24709,"90pt":3.24709,"95pt":3.24709,"99pt":3.24709,"avg":3.24709,"max":3.24709,"min":3.24709,"routers":[{"avg":3.24709,"monitors":[{"time":"2022-11-08 09:15:00 +0900 JST","traffic":3.24709}],"name":"example","zone":"tk1b"}]}
```